### PR TITLE
Export multiple definitions

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fm = require('formality-lang')
 const loaderUtils = require('loader-utils')
-const localLoader = require('formality-lang/cjs/fs-local.js')
+const localLoader = require('formality-lang/dist/fs-local.js').with_local_files;
 
 module.exports = function loader(content) {
   const options = loaderUtils.getOptions(this) || {}
@@ -24,11 +24,10 @@ module.exports = function loader(content) {
         .map(([name]) => path.join(this.context, name + '.fm'))
         .forEach(this.addDependency)
 
-      const refName = file + '/main'
+      //TODO: check all in defs
+      //if (shouldCheckTypes) fm.core.typecheck(refName, null, defs, {})
 
-      if (shouldCheckTypes) fm.core.typecheck(refName, null, defs, {})
-
-      const js = fm.js.compile(fm.core.Ref(refName), defs)
+      const js = fm.js.compile(file+"/@", defs)
       return 'module.exports = ' + js
     })
     .catch(err => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formality-loader",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Formality language loader for webpack",
   "homepage": "https://github.com/g-guimaraes/formality-loader",
   "repository": {
@@ -19,7 +19,8 @@
     "loader.js"
   ],
   "dependencies": {
-    "formality-lang": "^0.1.228"
+    "formality-lang": "^0.1.231",
+    "loader-utils": "^1.2.3"
   },
   "peerDependencies": {
     "webpack": "^4.41.4"


### PR DESCRIPTION
This exports all definitions inside the `.fm` file instead of just `main`, allowing this kind of usage:

```
var {
  demo_game_state,
  tick_game_state,
  render_game_state,
  apply_input_to_game_state
} = require("./fm/TaelinArena.fm");
```

It disables the type-checker (TODO).

It also updates the import of fs-local to the newest style.